### PR TITLE
Cleaning a couple of external API calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ version = "0.3.1"
 authors = ["Chris Holcombe <xfactor973@gmail.com>"]
 repository = "https://github.com/cholcombe973/Juju"
 license = "MIT"
+
+[dependencies]
+charmhelpers = "~0.1"


### PR DESCRIPTION
I'd suggest a major version bump at the same time as merging this in.
- use new charmhelpers crate for hook name
- do not use args in process_hooks
- pass fn directly into hook, instead of boxing it
